### PR TITLE
Fix data-yaml default value in documentation

### DIFF
--- a/DOCS/deployment/vertex_ai_training_guide.md
+++ b/DOCS/deployment/vertex_ai_training_guide.md
@@ -139,7 +139,7 @@ wc -c config/service_account.json
 | `--lr0`           | 浮動小数点 | 0.001          | 初期学習率           |
 | `--optimizer`     | 文字列     | AdamW          | オプティマイザ              |
 | `--iou-threshold` | 浮動小数点 | 0.5            | IoU閾値              |
-| `--data-yaml`     | 文字列     | data.yaml      | データセット設定ファイル       |
+| `--data-yaml`     | 文字列     | config/data.yaml | データセット設定ファイル       |
 | `--skip-build`    | フラグ        | false          | ビルドをスキップ             |
 | `--help`          | フラグ        | -              | ヘルプ表示              |
 


### PR DESCRIPTION
## Summary
Fixed incorrect default value for `--data-yaml` option in Vertex AI training guide documentation.

## Changes
- Updated default value from `data.yaml` to `config/data.yaml` in the options table
- This matches the actual implementation in the training scripts

## Context
This fix was identified in a code review comment but wasn't included in the previous PR #79 which was already merged.

🤖 Generated with [Claude Code](https://claude.ai/code)